### PR TITLE
Optimize performance

### DIFF
--- a/srfi.160.base.scm
+++ b/srfi.160.base.scm
@@ -4,6 +4,7 @@
   (import (only (chicken module) export))
   (import (only (chicken bitwise) bitwise-and bitwise-ior
                            bitwise-not arithmetic-shift))
+  (import chicken.fixnum)
 
   ;; SRFI 4 versions of @vector->list don't accept start/end args
   (import (except (srfi 4)

--- a/srfi.160.c128.scm
+++ b/srfi.160.c128.scm
@@ -1,9 +1,12 @@
+(declare (fixnum-arithmetic))
+
 (module (srfi 160 c128) ()
   (import (scheme))
   (import (only (chicken base)
     open-input-string include define-record-type case-lambda
     when unless let-values))
   (import (only (chicken module) export))
+  (import (only (chicken memory) move-memory!))
   (import (srfi 128))
   (import (srfi 160 base))
 

--- a/srfi.160.c64.scm
+++ b/srfi.160.c64.scm
@@ -1,9 +1,12 @@
+(declare (fixnum-arithmetic))
+
 (module (srfi 160 c64) ()
   (import (scheme))
   (import (only (chicken base)
     open-input-string include define-record-type case-lambda
     when unless let-values))
   (import (only (chicken module) export))
+  (import (only (chicken memory) move-memory!))
   (import (srfi 128))
   (import (srfi 160 base))
 

--- a/srfi.160.f32.scm
+++ b/srfi.160.f32.scm
@@ -1,9 +1,12 @@
+(declare (fixnum-arithmetic))
+
 (module (srfi 160 f32) ()
   (import (scheme))
   (import (only (chicken base)
     open-input-string include define-record-type case-lambda
     when unless let-values))
   (import (only (chicken module) export))
+  (import (only (chicken memory) move-memory!))
   (import (srfi 128))
   (import (srfi 160 base))
 

--- a/srfi.160.f64.scm
+++ b/srfi.160.f64.scm
@@ -1,9 +1,12 @@
+(declare (fixnum-arithmetic))
+
 (module (srfi 160 f64) ()
   (import (scheme))
   (import (only (chicken base)
     open-input-string include define-record-type case-lambda
     when unless let-values))
   (import (only (chicken module) export))
+  (import (only (chicken memory) move-memory!))
   (import (srfi 128))
   (import (srfi 160 base))
 

--- a/srfi.160.s16.scm
+++ b/srfi.160.s16.scm
@@ -1,9 +1,12 @@
+(declare (fixnum-arithmetic))
+
 (module (srfi 160 s16) ()
   (import (scheme))
   (import (only (chicken base)
     open-input-string include define-record-type case-lambda
     when unless let-values))
   (import (only (chicken module) export))
+  (import (only (chicken memory) move-memory!))
   (import (srfi 128))
   (import (srfi 160 base))
 

--- a/srfi.160.s32.scm
+++ b/srfi.160.s32.scm
@@ -1,9 +1,12 @@
+(declare (fixnum-arithmetic))
+
 (module (srfi 160 s32) ()
   (import (scheme))
   (import (only (chicken base)
     open-input-string include define-record-type case-lambda
     when unless let-values))
   (import (only (chicken module) export))
+  (import (only (chicken memory) move-memory!))
   (import (srfi 128))
   (import (srfi 160 base))
 

--- a/srfi.160.s64.scm
+++ b/srfi.160.s64.scm
@@ -1,9 +1,12 @@
+(declare (fixnum-arithmetic))
+
 (module (srfi 160 s64) ()
   (import (scheme))
   (import (only (chicken base)
     open-input-string include define-record-type case-lambda
     when unless let-values))
   (import (only (chicken module) export))
+  (import (only (chicken memory) move-memory!))
   (import (srfi 128))
   (import (srfi 160 base))
 

--- a/srfi.160.s8.scm
+++ b/srfi.160.s8.scm
@@ -1,9 +1,12 @@
+(declare (fixnum-arithmetic))
+
 (module (srfi 160 s8) ()
   (import (scheme))
   (import (only (chicken base)
     open-input-string include define-record-type case-lambda
     when unless let-values))
   (import (only (chicken module) export))
+  (import (only (chicken memory) move-memory!))
   (import (srfi 128))
   (import (srfi 160 base))
 

--- a/srfi.160.u16.scm
+++ b/srfi.160.u16.scm
@@ -1,9 +1,12 @@
+(declare (fixnum-arithmetic))
+
 (module (srfi 160 u16) ()
   (import (scheme))
   (import (only (chicken base)
     open-input-string include define-record-type case-lambda
     when unless let-values))
   (import (only (chicken module) export))
+  (import (only (chicken memory) move-memory!))
   (import (srfi 128))
   (import (srfi 160 base))
 

--- a/srfi.160.u32.scm
+++ b/srfi.160.u32.scm
@@ -1,9 +1,12 @@
+(declare (fixnum-arithmetic))
+
 (module (srfi 160 u32) ()
   (import (scheme))
   (import (only (chicken base)
     open-input-string include define-record-type case-lambda
     when unless let-values))
   (import (only (chicken module) export))
+  (import (only (chicken memory) move-memory!))
   (import (srfi 128))
   (import (srfi 160 base))
 

--- a/srfi.160.u64.scm
+++ b/srfi.160.u64.scm
@@ -1,9 +1,12 @@
+(declare (fixnum-arithmetic))
+
 (module (srfi 160 u64) ()
   (import (scheme))
   (import (only (chicken base)
     open-input-string include define-record-type case-lambda
     when unless let-values))
   (import (only (chicken module) export))
+  (import (only (chicken memory) move-memory!))
   (import (srfi 128))
   (import (srfi 160 base))
 

--- a/srfi.160.u8.scm
+++ b/srfi.160.u8.scm
@@ -1,9 +1,12 @@
+(declare (fixnum-arithmetic))
+
 (module (srfi 160 u8) ()
   (import (scheme))
   (import (only (chicken base)
     open-input-string include define-record-type case-lambda
     when unless let-values))
   (import (only (chicken module) export))
+  (import (only (chicken memory) move-memory!))
   (import (srfi 128))
   (import (srfi 160 base))
 

--- a/srfi/160/base/c128-vector2list.scm
+++ b/srfi/160/base/c128-vector2list.scm
@@ -7,9 +7,9 @@
     ((vec start end) (c128vector->list* vec start end))))
 
 (define (c128vector->list* vec start end)
-  (let loop ((i (- end 1))
+  (let loop ((i (fx- end 1))
              (list '()))
-    (if (< i start)
+    (if (fx< i start)
       list
-      (loop (- i 1) (cons (c128vector-ref vec i) list)))))
+      (loop (fx- i 1) (cons (c128vector-ref vec i) list)))))
 

--- a/srfi/160/base/c64-vector2list.scm
+++ b/srfi/160/base/c64-vector2list.scm
@@ -7,9 +7,9 @@
     ((vec start end) (c64vector->list* vec start end))))
 
 (define (c64vector->list* vec start end)
-  (let loop ((i (- end 1))
+  (let loop ((i (fx- end 1))
              (list '()))
-    (if (< i start)
+    (if (fx< i start)
       list
-      (loop (- i 1) (cons (c64vector-ref vec i) list)))))
+      (loop (fx- i 1) (cons (c64vector-ref vec i) list)))))
 

--- a/srfi/160/base/complex.scm
+++ b/srfi/160/base/complex.scm
@@ -3,13 +3,13 @@
 ;;; Main constructor
 
 (define (make-c64vector len . maybe-fill)
-  (define vec (raw-make-c64vector (make-f32vector (* len 2))))
+  (define vec (raw-make-c64vector (make-f32vector (fx* len 2))))
   (if (not (null? maybe-fill))
     (c64vector-simple-fill! vec (car maybe-fill)))
   vec)
 
 (define (make-c128vector len . maybe-fill)
-  (define vec (raw-make-c128vector (make-f64vector (* len 2))))
+  (define vec (raw-make-c128vector (make-f64vector (fx* len 2))))
   (if (not (null? maybe-fill))
     (c128vector-simple-fill! vec (car maybe-fill)))
   vec)
@@ -19,20 +19,20 @@
 (define (c64vector-simple-fill! vec value)
   (define len (c64vector-length vec))
   (let loop ((i 0))
-    (if (= i len)
+    (if (fx= i len)
       vec
       (begin
         (c64vector-set! vec i value)
-        (loop (+ i 1))))))
+        (loop (fx+ i 1))))))
 
 (define (c128vector-simple-fill! vec value)
   (define len (c128vector-length vec))
   (let loop ((i 0))
-    (if (= i len)
+    (if (fx= i len)
       vec
       (begin
         (c128vector-set! vec i value)
-        (loop (+ i 1))))))
+        (loop (fx+ i 1))))))
 
 ;;; Variable-argument constructor
 
@@ -47,40 +47,40 @@
 ;; Length
 
 (define (c64vector-length vec)
-  (/ (f32vector-length (bv64 vec)) 2))
+  (fx/ (f32vector-length (bv64 vec)) 2))
 
 (define (c128vector-length vec)
-  (/ (f64vector-length (bv128 vec)) 2))
+  (fx/ (f64vector-length (bv128 vec)) 2))
 
 ;; Get element
 
 (define (c64vector-ref vec i)
   (let ((fvec (bv64 vec))
-        (j (* i 2)))
+        (j (fx* i 2)))
     (make-rectangular
       (f32vector-ref fvec j)
-      (f32vector-ref fvec (+ j 1)))))
+      (f32vector-ref fvec (fx+ j 1)))))
 
 (define (c128vector-ref vec i)
   (let ((fvec (bv128 vec))
-        (j (* i 2)))
+        (j (fx* i 2)))
     (make-rectangular
       (f64vector-ref fvec j)
-      (f64vector-ref fvec (+ j 1)))))
+      (f64vector-ref fvec (fx+ j 1)))))
 
 ;; Set element
 
 (define (c64vector-set! vec i value)
   (let ((fvec (bv64 vec))
-        (j (* i 2)))
+        (j (fx* i 2)))
     (f32vector-set! fvec j (real-part value))
-    (f32vector-set! fvec (+ j 1) (imag-part value))))
+    (f32vector-set! fvec (fx+ j 1) (imag-part value))))
 
 (define (c128vector-set! vec i value)
   (let ((fvec (bv128 vec))
-        (j (* i 2)))
+        (j (fx* i 2)))
     (f64vector-set! fvec j (real-part value))
-    (f64vector-set! fvec (+ j 1) (imag-part value))))
+    (f64vector-set! fvec (fx+ j 1) (imag-part value))))
 
 ;; List to vec
 
@@ -88,21 +88,21 @@
   (define len (length list))
   (define vec (make-c64vector len))
   (let loop ((i 0) (list list))
-    (if (= i len)
+    (if (fx= i len)
       vec
       (begin
         (c64vector-set! vec i (car list))
-        (loop (+ i 1) (cdr list))))))
+        (loop (fx+ i 1) (cdr list))))))
 
 (define (list->c128vector list)
   (define len (length list))
   (define vec (make-c128vector len))
   (let loop ((i 0) (list list))
-    (if (= i len)
+    (if (fx= i len)
       vec
       (begin
         (c128vector-set! vec i (car list))
-        (loop (+ i 1) (cdr list))))))
+        (loop (fx+ i 1) (cdr list))))))
 
 ;; Vec to list defined in at-vector2list
 

--- a/srfi/160/base/f32-vector2list.scm
+++ b/srfi/160/base/f32-vector2list.scm
@@ -2,14 +2,6 @@
 
 (define f32vector->list
   (case-lambda
-    ((vec) (f32vector->list* vec 0 (f32vector-length vec)))
-    ((vec start) (f32vector->list* vec start (f32vector-length vec)))
-    ((vec start end) (f32vector->list* vec start end))))
-
-(define (f32vector->list* vec start end)
-  (let loop ((i (- end 1))
-             (list '()))
-    (if (< i start)
-      list
-      (loop (- i 1) (cons (f32vector-ref vec i) list)))))
-
+    ((vec) (f32vector->list vec))
+    ((vec start) (f32vector->list (subf32vector vec start (f32vector-length vec))))
+    ((vec start end) (f32vector->list (subf32vector vec start end)))))

--- a/srfi/160/base/f64-vector2list.scm
+++ b/srfi/160/base/f64-vector2list.scm
@@ -2,14 +2,6 @@
 
 (define f64vector->list
   (case-lambda
-    ((vec) (f64vector->list* vec 0 (f64vector-length vec)))
-    ((vec start) (f64vector->list* vec start (f64vector-length vec)))
-    ((vec start end) (f64vector->list* vec start end))))
-
-(define (f64vector->list* vec start end)
-  (let loop ((i (- end 1))
-             (list '()))
-    (if (< i start)
-      list
-      (loop (- i 1) (cons (f64vector-ref vec i) list)))))
-
+    ((vec) (f64vector->list vec))
+    ((vec start) (f64vector->list (subf64vector vec start (f64vector-length vec))))
+    ((vec start end) (f64vector->list (subf64vector vec start end)))))

--- a/srfi/160/base/s16-vector2list.scm
+++ b/srfi/160/base/s16-vector2list.scm
@@ -2,14 +2,6 @@
 
 (define s16vector->list
   (case-lambda
-    ((vec) (s16vector->list* vec 0 (s16vector-length vec)))
-    ((vec start) (s16vector->list* vec start (s16vector-length vec)))
-    ((vec start end) (s16vector->list* vec start end))))
-
-(define (s16vector->list* vec start end)
-  (let loop ((i (- end 1))
-             (list '()))
-    (if (< i start)
-      list
-      (loop (- i 1) (cons (s16vector-ref vec i) list)))))
-
+    ((vec) (s16vector->list vec))
+    ((vec start) (s16vector->list (subs16vector vec start (s16vector-length vec))))
+    ((vec start end) (s16vector->list (subs16vector vec start end)))))

--- a/srfi/160/base/s32-vector2list.scm
+++ b/srfi/160/base/s32-vector2list.scm
@@ -2,14 +2,6 @@
 
 (define s32vector->list
   (case-lambda
-    ((vec) (s32vector->list* vec 0 (s32vector-length vec)))
-    ((vec start) (s32vector->list* vec start (s32vector-length vec)))
-    ((vec start end) (s32vector->list* vec start end))))
-
-(define (s32vector->list* vec start end)
-  (let loop ((i (- end 1))
-             (list '()))
-    (if (< i start)
-      list
-      (loop (- i 1) (cons (s32vector-ref vec i) list)))))
-
+    ((vec) (s32vector->list vec))
+    ((vec start) (s32vector->list (subs32vector vec start (s32vector-length vec))))
+    ((vec start end) (s32vector->list (subs32vector vec start end)))))

--- a/srfi/160/base/s64-vector2list.scm
+++ b/srfi/160/base/s64-vector2list.scm
@@ -2,14 +2,6 @@
 
 (define s64vector->list
   (case-lambda
-    ((vec) (s64vector->list* vec 0 (s64vector-length vec)))
-    ((vec start) (s64vector->list* vec start (s64vector-length vec)))
-    ((vec start end) (s64vector->list* vec start end))))
-
-(define (s64vector->list* vec start end)
-  (let loop ((i (- end 1))
-             (list '()))
-    (if (< i start)
-      list
-      (loop (- i 1) (cons (s64vector-ref vec i) list)))))
-
+    ((vec) (s64vector->list vec))
+    ((vec start) (s64vector->list (subs64vector vec start (s64vector-length vec))))
+    ((vec start end) (s64vector->list (subs64vector vec start end)))))

--- a/srfi/160/base/s8-vector2list.scm
+++ b/srfi/160/base/s8-vector2list.scm
@@ -2,14 +2,6 @@
 
 (define s8vector->list
   (case-lambda
-    ((vec) (s8vector->list* vec 0 (s8vector-length vec)))
-    ((vec start) (s8vector->list* vec start (s8vector-length vec)))
-    ((vec start end) (s8vector->list* vec start end))))
-
-(define (s8vector->list* vec start end)
-  (let loop ((i (- end 1))
-             (list '()))
-    (if (< i start)
-      list
-      (loop (- i 1) (cons (s8vector-ref vec i) list)))))
-
+    ((vec) (s8vector->list vec))
+    ((vec start) (s8vector->list (subs8vector vec start (s8vector-length vec))))
+    ((vec start end) (s8vector->list (subs8vector vec start end)))))

--- a/srfi/160/base/u16-vector2list.scm
+++ b/srfi/160/base/u16-vector2list.scm
@@ -2,14 +2,6 @@
 
 (define u16vector->list
   (case-lambda
-    ((vec) (u16vector->list* vec 0 (u16vector-length vec)))
-    ((vec start) (u16vector->list* vec start (u16vector-length vec)))
-    ((vec start end) (u16vector->list* vec start end))))
-
-(define (u16vector->list* vec start end)
-  (let loop ((i (- end 1))
-             (list '()))
-    (if (< i start)
-      list
-      (loop (- i 1) (cons (u16vector-ref vec i) list)))))
-
+    ((vec) (u16vector->list vec))
+    ((vec start) (u16vector->list (subu16vector vec start (u16vector-length vec))))
+    ((vec start end) (u16vector->list (subu16vector vec start end)))))

--- a/srfi/160/base/u32-vector2list.scm
+++ b/srfi/160/base/u32-vector2list.scm
@@ -2,14 +2,6 @@
 
 (define u32vector->list
   (case-lambda
-    ((vec) (u32vector->list* vec 0 (u32vector-length vec)))
-    ((vec start) (u32vector->list* vec start (u32vector-length vec)))
-    ((vec start end) (u32vector->list* vec start end))))
-
-(define (u32vector->list* vec start end)
-  (let loop ((i (- end 1))
-             (list '()))
-    (if (< i start)
-      list
-      (loop (- i 1) (cons (u32vector-ref vec i) list)))))
-
+    ((vec) (u32vector->list vec))
+    ((vec start) (u32vector->list (subu32vector vec start (u32vector-length vec))))
+    ((vec start end) (u32vector->list (subu32vector vec start end)))))

--- a/srfi/160/base/u64-vector2list.scm
+++ b/srfi/160/base/u64-vector2list.scm
@@ -2,14 +2,7 @@
 
 (define u64vector->list
   (case-lambda
-    ((vec) (u64vector->list* vec 0 (u64vector-length vec)))
-    ((vec start) (u64vector->list* vec start (u64vector-length vec)))
-    ((vec start end) (u64vector->list* vec start end))))
-
-(define (u64vector->list* vec start end)
-  (let loop ((i (- end 1))
-             (list '()))
-    (if (< i start)
-      list
-      (loop (- i 1) (cons (u64vector-ref vec i) list)))))
+    ((vec) (u64vector->list vec))
+    ((vec start) (u64vector->list (subu64vector vec start (u64vector-length vec))))
+    ((vec start end) (u64vector->list (subu64vector vec start end)))))
 

--- a/srfi/160/base/u8-vector2list.scm
+++ b/srfi/160/base/u8-vector2list.scm
@@ -2,14 +2,6 @@
 
 (define u8vector->list
   (case-lambda
-    ((vec) (u8vector->list* vec 0 (u8vector-length vec)))
-    ((vec start) (u8vector->list* vec start (u8vector-length vec)))
-    ((vec start end) (u8vector->list* vec start end))))
-
-(define (u8vector->list* vec start end)
-  (let loop ((i (- end 1))
-             (list '()))
-    (if (< i start)
-      list
-      (loop (- i 1) (cons (u8vector-ref vec i) list)))))
-
+    ((vec) (u8vector->list vec))
+    ((vec start) (u8vector->list (subu8vector vec start (u8vector-length vec))))
+    ((vec start end) (u8vector->list (subu8vector vec start end)))))

--- a/srfi/160/c128-impl.scm
+++ b/srfi/160/c128-impl.scm
@@ -37,16 +37,20 @@
 (define c128vector-copy!
   (case-lambda
     ((to at from)
-     (c128vector-copy!* to at from 0 (c128vector-length from)))
+     (let ((to (##sys#slot to 1))
+           (from (##sys#slot from 1)))
+       (move-memory! from to (f64vector-length from) 0 (* at 16))))
     ((to at from start)
-     (c128vector-copy!* to at from start (c128vector-length from)))
-    ((to at from start end) (c128vector-copy!* to at from start end))))
-
-(define (c128vector-copy!* to at from start end)
-  (let loop ((at at) (i start))
-    (unless (= i end)
-      (c128vector-set! to at (c128vector-ref from i))
-      (loop (+ at 1) (+ i 1)))))
+     (let ((to (##sys#slot to 1))
+           (from (##sys#slot from 1)))
+       (move-memory! from to (f64vector-length from) (* start 16) (* at 16))))
+    ((to at from start end)
+     (let ((to (##sys#slot to 1))
+           (from (##sys#slot from 1)))
+       (move-memory! from to
+                     (* 16 (- end start))
+                     (* start 16)
+                     (* at 16))))))
 
 (define c128vector-reverse-copy
   (case-lambda

--- a/srfi/160/c64-impl.scm
+++ b/srfi/160/c64-impl.scm
@@ -37,16 +37,20 @@
 (define c64vector-copy!
   (case-lambda
     ((to at from)
-     (c64vector-copy!* to at from 0 (c64vector-length from)))
+     (let ((to (##sys#slot to 1))
+           (from (##sys#slot from 1)))
+       (move-memory! from to (f32vector-length from) 0 (* at 8))))
     ((to at from start)
-     (c64vector-copy!* to at from start (c64vector-length from)))
-    ((to at from start end) (c64vector-copy!* to at from start end))))
-
-(define (c64vector-copy!* to at from start end)
-  (let loop ((at at) (i start))
-    (unless (= i end)
-      (c64vector-set! to at (c64vector-ref from i))
-      (loop (+ at 1) (+ i 1)))))
+     (let ((to (##sys#slot to 1))
+           (from (##sys#slot from 1)))
+       (move-memory! from to (f32vector-length from) (* start 8) (* at 8))))
+    ((to at from start end)
+     (let ((to (##sys#slot to 1))
+           (from (##sys#slot from 1)))
+       (move-memory! from to
+                     (* 8 (- end start))
+                     (* start 8)
+                     (* at 8))))))
 
 (define c64vector-reverse-copy
   (case-lambda

--- a/srfi/160/f32-impl.scm
+++ b/srfi/160/f32-impl.scm
@@ -37,16 +37,14 @@
 (define f32vector-copy!
   (case-lambda
     ((to at from)
-     (f32vector-copy!* to at from 0 (f32vector-length from)))
+     (move-memory! from to (f32vector-length from) 0 (* at 4)))
     ((to at from start)
-     (f32vector-copy!* to at from start (f32vector-length from)))
-    ((to at from start end) (f32vector-copy!* to at from start end))))
-
-(define (f32vector-copy!* to at from start end)
-  (let loop ((at at) (i start))
-    (unless (= i end)
-      (f32vector-set! to at (f32vector-ref from i))
-      (loop (+ at 1) (+ i 1)))))
+     (move-memory! from to (f32vector-length from) (* start 4) (* at 4)))
+    ((to at from start end)
+     (move-memory! from to
+                   (* 4 (- end start))
+                   (* start 4)
+                   (* at 4)))))
 
 (define f32vector-reverse-copy
   (case-lambda

--- a/srfi/160/f64-impl.scm
+++ b/srfi/160/f64-impl.scm
@@ -37,16 +37,14 @@
 (define f64vector-copy!
   (case-lambda
     ((to at from)
-     (f64vector-copy!* to at from 0 (f64vector-length from)))
+     (move-memory! from to (f64vector-length from) 0 (* at 8)))
     ((to at from start)
-     (f64vector-copy!* to at from start (f64vector-length from)))
-    ((to at from start end) (f64vector-copy!* to at from start end))))
-
-(define (f64vector-copy!* to at from start end)
-  (let loop ((at at) (i start))
-    (unless (= i end)
-      (f64vector-set! to at (f64vector-ref from i))
-      (loop (+ at 1) (+ i 1)))))
+     (move-memory! from to (f64vector-length from) (* start 8) (* at 8)))
+    ((to at from start end)
+     (move-memory! from to
+                   (* 8 (- end start))
+                   (* start 8)
+                   (* at 8)))))
 
 (define f64vector-reverse-copy
   (case-lambda

--- a/srfi/160/s16-impl.scm
+++ b/srfi/160/s16-impl.scm
@@ -37,16 +37,14 @@
 (define s16vector-copy!
   (case-lambda
     ((to at from)
-     (s16vector-copy!* to at from 0 (s16vector-length from)))
+     (move-memory! from to (s16vector-length from) 0 (* at 2)))
     ((to at from start)
-     (s16vector-copy!* to at from start (s16vector-length from)))
-    ((to at from start end) (s16vector-copy!* to at from start end))))
-
-(define (s16vector-copy!* to at from start end)
-  (let loop ((at at) (i start))
-    (unless (= i end)
-      (s16vector-set! to at (s16vector-ref from i))
-      (loop (+ at 1) (+ i 1)))))
+     (move-memory! from to (s16vector-length from) (* start 2) (* at 2)))
+    ((to at from start end)
+     (move-memory! from to
+                   (* 2 (- end start))
+                   (* start 2)
+                   (* at 2)))))
 
 (define s16vector-reverse-copy
   (case-lambda

--- a/srfi/160/s32-impl.scm
+++ b/srfi/160/s32-impl.scm
@@ -37,16 +37,14 @@
 (define s32vector-copy!
   (case-lambda
     ((to at from)
-     (s32vector-copy!* to at from 0 (s32vector-length from)))
+     (move-memory! from to (s32vector-length from) 0 (* at 4)))
     ((to at from start)
-     (s32vector-copy!* to at from start (s32vector-length from)))
-    ((to at from start end) (s32vector-copy!* to at from start end))))
-
-(define (s32vector-copy!* to at from start end)
-  (let loop ((at at) (i start))
-    (unless (= i end)
-      (s32vector-set! to at (s32vector-ref from i))
-      (loop (+ at 1) (+ i 1)))))
+     (move-memory! from to (s32vector-length from) (* start 4) (* at 4)))
+    ((to at from start end)
+     (move-memory! from to
+                   (* 4 (- end start))
+                   (* start 4)
+                   (* at 4)))))
 
 (define s32vector-reverse-copy
   (case-lambda

--- a/srfi/160/s64-impl.scm
+++ b/srfi/160/s64-impl.scm
@@ -37,16 +37,14 @@
 (define s64vector-copy!
   (case-lambda
     ((to at from)
-     (s64vector-copy!* to at from 0 (s64vector-length from)))
+     (move-memory! from to (s64vector-length from) 0 (* at 8)))
     ((to at from start)
-     (s64vector-copy!* to at from start (s64vector-length from)))
-    ((to at from start end) (s64vector-copy!* to at from start end))))
-
-(define (s64vector-copy!* to at from start end)
-  (let loop ((at at) (i start))
-    (unless (= i end)
-      (s64vector-set! to at (s64vector-ref from i))
-      (loop (+ at 1) (+ i 1)))))
+     (move-memory! from to (s64vector-length from) (* start 8) (* at 8)))
+    ((to at from start end)
+     (move-memory! from to
+                   (* 8 (- end start))
+                   (* start 8)
+                   (* at 8)))))
 
 (define s64vector-reverse-copy
   (case-lambda

--- a/srfi/160/s8-impl.scm
+++ b/srfi/160/s8-impl.scm
@@ -37,16 +37,14 @@
 (define s8vector-copy!
   (case-lambda
     ((to at from)
-     (s8vector-copy!* to at from 0 (s8vector-length from)))
+     (move-memory! from to (s8vector-length from) 0 at))
     ((to at from start)
-     (s8vector-copy!* to at from start (s8vector-length from)))
-    ((to at from start end) (s8vector-copy!* to at from start end))))
-
-(define (s8vector-copy!* to at from start end)
-  (let loop ((at at) (i start))
-    (unless (= i end)
-      (s8vector-set! to at (s8vector-ref from i))
-      (loop (+ at 1) (+ i 1)))))
+     (move-memory! from to (s8vector-length from) start at))
+    ((to at from start end)
+     (move-memory! from to
+                   (- end start)
+                   start
+                   at))))
 
 (define s8vector-reverse-copy
   (case-lambda

--- a/srfi/160/u16-impl.scm
+++ b/srfi/160/u16-impl.scm
@@ -37,16 +37,14 @@
 (define u16vector-copy!
   (case-lambda
     ((to at from)
-     (u16vector-copy!* to at from 0 (u16vector-length from)))
+     (move-memory! from to (u16vector-length from) 0 (* at 2)))
     ((to at from start)
-     (u16vector-copy!* to at from start (u16vector-length from)))
-    ((to at from start end) (u16vector-copy!* to at from start end))))
-
-(define (u16vector-copy!* to at from start end)
-  (let loop ((at at) (i start))
-    (unless (= i end)
-      (u16vector-set! to at (u16vector-ref from i))
-      (loop (+ at 1) (+ i 1)))))
+     (move-memory! from to (u16vector-length from) (* start 2) (* at 2)))
+    ((to at from start end)
+     (move-memory! from to
+                   (* 2 (- end start))
+                   (* start 2)
+                   (* at 2)))))
 
 (define u16vector-reverse-copy
   (case-lambda

--- a/srfi/160/u32-impl.scm
+++ b/srfi/160/u32-impl.scm
@@ -37,16 +37,14 @@
 (define u32vector-copy!
   (case-lambda
     ((to at from)
-     (u32vector-copy!* to at from 0 (u32vector-length from)))
+     (move-memory! from to (u32vector-length from) 0 (* at 4)))
     ((to at from start)
-     (u32vector-copy!* to at from start (u32vector-length from)))
-    ((to at from start end) (u32vector-copy!* to at from start end))))
-
-(define (u32vector-copy!* to at from start end)
-  (let loop ((at at) (i start))
-    (unless (= i end)
-      (u32vector-set! to at (u32vector-ref from i))
-      (loop (+ at 1) (+ i 1)))))
+     (move-memory! from to (u32vector-length from) (* start 4) (* at 4)))
+    ((to at from start end)
+     (move-memory! from to
+                   (* 4 (- end start))
+                   (* start 4)
+                   (* at 4)))))
 
 (define u32vector-reverse-copy
   (case-lambda

--- a/srfi/160/u64-impl.scm
+++ b/srfi/160/u64-impl.scm
@@ -37,16 +37,14 @@
 (define u64vector-copy!
   (case-lambda
     ((to at from)
-     (u64vector-copy!* to at from 0 (u64vector-length from)))
+     (move-memory! from to (u64vector-length from) 0 (* at 8)))
     ((to at from start)
-     (u64vector-copy!* to at from start (u64vector-length from)))
-    ((to at from start end) (u64vector-copy!* to at from start end))))
-
-(define (u64vector-copy!* to at from start end)
-  (let loop ((at at) (i start))
-    (unless (= i end)
-      (u64vector-set! to at (u64vector-ref from i))
-      (loop (+ at 1) (+ i 1)))))
+     (move-memory! from to (u64vector-length from) (* start 8) (* at 8)))
+    ((to at from start end)
+     (move-memory! from to
+                   (* 8 (- end start))
+                   (* start 8)
+                   (* at 8)))))
 
 (define u64vector-reverse-copy
   (case-lambda

--- a/srfi/160/u8-impl.scm
+++ b/srfi/160/u8-impl.scm
@@ -37,16 +37,14 @@
 (define u8vector-copy!
   (case-lambda
     ((to at from)
-     (u8vector-copy!* to at from 0 (u8vector-length from)))
+     (move-memory! from to (u8vector-length from) 0 at))
     ((to at from start)
-     (u8vector-copy!* to at from start (u8vector-length from)))
-    ((to at from start end) (u8vector-copy!* to at from start end))))
-
-(define (u8vector-copy!* to at from start end)
-  (let loop ((at at) (i start))
-    (unless (= i end)
-      (u8vector-set! to at (u8vector-ref from i))
-      (loop (+ at 1) (+ i 1)))))
+     (move-memory! from to (u8vector-length from) start at))
+    ((to at from start end)
+     (move-memory! from to
+                   (- end start)
+                   start
+                   at))))
 
 (define u8vector-reverse-copy
   (case-lambda


### PR DESCRIPTION
- Since all arithmetic is dealing with srfi-4 vector indices, which are
  guaranteed to be smaller that most-positive-fixnum, we can enable
  fixnum-arithmetic.
- We can use the built-in srfi-4 sub@vector and @vector->list to
  implement srfi-160's @vector->list
- It's much faster to use move-memory!, which does a memmove, for
  copying vectors, than looping through every index.
  + Because bv64 and bv128 aren't exported, we have to use ##sys#slot to
    access the actual bytevector body of complex vectors for this.
    Still, I think the performance improvement makes it worth it.